### PR TITLE
fix(names): cleanup transformed names from ColumnTransformer

### DIFF
--- a/feature_transform/transform.py
+++ b/feature_transform/transform.py
@@ -97,8 +97,22 @@ def _get_transformed_names(col_transfmr: ColumnTransformer, trans: Union[str, Tr
     return [f'{col}' for col in trans.get_feature_names_out()]
 
 
+def _dedupe_ct_prefix(name: str) -> str:
+    '''Remove transfomer__pipeline name prefix dupe like {NAME}__{NAME}_{n}'''
+    left, right = name.split('__')
+    if right.startswith(left):
+        return right
+    else:
+        return name
+
+
 def get_transformed_names(col_transfmr: ColumnTransformer) -> list:
     '''Get the transformed_names for ColumnTransformer'''
+    try:
+        transformed_names = col_transfmr.get_feature_names_out()  # use the built in if available
+        return [_dedupe_ct_prefix(name) for name in transformed_names]
+    except Exception:
+        pass
     # allow transformers to be pipelines. Pipeline steps are ordered differently, so need some processing
     if type(col_transfmr) == Pipeline:
         tfmrs_list = [(_auto_name, trans, None, None) for step, _auto_name, trans in col_transfmr._iter()]

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ class PyTest(TestCommand):
 
 setup(
     name='feature_transform',
-    version='0.4.0',
+    version='0.4.1',
     description='Build feature transformer by specifying transformation.',
     long_description='https://github.com/kengz/feature_transform',
     keywords='feature_transform',


### PR DESCRIPTION
The builtin `ColumnTransformer.get_feature_names_out()` duplicates the given column name between transformer and its inner pipeline, resulting in names like `['target__target_0', 'target__target_1', 'target__target_2']`. This adds a clean up step so we get names like `['target_0', 'target_1', 'target_2']` as desired.